### PR TITLE
Removed the deprecated modules section from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,6 @@
   "engines": {
     "node": "*"
   },
-  "modules": {
-    "observer.js": "lib/relative-date.js"
-  },
-  "files": [
-    ""
-  ],
   "homepage": "http://github.com/azer/relative-date",
   "repository": { "type":"git",  "url" : "http://github.com/azer/relative-date.git" },
   "scripts": {


### PR DESCRIPTION
Running node 0.4.8 and npm 1.0.6, npm complains:
"npm ERR! incorrect json: relative-date Error: modules object is deprecated"

I simply removed the modules section (and the unused files section) which should fix this.
